### PR TITLE
Additional s3 config options and functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,12 +80,12 @@ S3Bucket.prototype.handle = function (ctx, next) {
         remaining++;
 
         if (bucket.events.upload) {
-          bucket.events.upload.run(ctx, {url: ctx.url, fileSize: file.size, fileName: file.filename}, function(err) {
+          bucket.events.upload.run(ctx, {url: ctx.url, fileSize: file.size, fileName: ctx.url}, function(err) {
             if (err) return uploadedFile(err);
-            bucket.uploadFile(file.filename, file.size, file.mime, fs.createReadStream(file.path), uploadedFile);  
+            bucket.uploadFile(ctx.url, file.size, file.type, fs.createReadStream(file.path), uploadedFile);  
           });
         } else {
-          bucket.uploadFile(file.filename, file.size, file.mime, fs.createReadStream(file.path), uploadedFile);
+          bucket.uploadFile(ctx.url, file.size, file.type, fs.createReadStream(file.path), uploadedFile);
         }
       })
       .on('error', function(err) {


### PR DESCRIPTION
1. s3 requires the region now in the url, so provide a config option for setting that value
2. added config boolean to enable setting the "publicRead" flag when uploading a file.
3. switched to using ctx.url instead of filename in the upload and get paths to s3 so that you can upload a file or nest files in additional folder structures.
